### PR TITLE
Changed logging level of invalid cp pointer

### DIFF
--- a/src/flexsea_comm_multi.c
+++ b/src/flexsea_comm_multi.c
@@ -260,7 +260,7 @@ uint8_t receiveAndFillResponse(uint8_t cmd_7bits, uint8_t pType, MultiPacketInfo
 	}
 	else
 	{
-		LOG(lerror,"Invalid cp pointer")
+		LOG(ldebug2,"Empty unpack array")
 	}
 	cp->in.frameMap = 0;
 	#ifdef BOARD_TYPE_FLEXSEA_PLAN


### PR DESCRIPTION
It was spamming the logs, so I changed the message to be more appropriate and changed the logging level to represent the severity